### PR TITLE
YamlDocumentFactory: Ignore trailing newline in multiline chunks

### DIFF
--- a/src/Services/YamlDocumentFactory.php
+++ b/src/Services/YamlDocumentFactory.php
@@ -34,6 +34,8 @@ class YamlDocumentFactory
 
     public function process(string $content): void
     {
+        $content = rtrim($content, "\n");
+
         $lines = explode("\n", $content);
 
         foreach ($lines as $line) {

--- a/tests/Unit/Services/YamlDocumentFactoryTest.php
+++ b/tests/Unit/Services/YamlDocumentFactoryTest.php
@@ -176,6 +176,21 @@ class YamlDocumentFactoryTest extends TestCase
                     ),
                 ],
             ],
+            'newline at end of multi-link chunks is ignored' => [
+                'contentChunks' => [
+                    "---\n",
+                    "- item1\n- item2\n",
+                    "- item3\n",
+                    '...',
+                ],
+                'expectedDocuments' => [
+                    new Document(
+                        '- item1' . "\n" .
+                        '- item2' . "\n" .
+                        '- item3' . "\n"
+                    ),
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes #204