### PR TITLE
Test basil fixtures should use http urls not https

### DIFF
--- a/tests/Fixtures/basil/Test/chrome-open-index.yml
+++ b/tests/Fixtures/basil/Test/chrome-open-index.yml
@@ -1,8 +1,8 @@
 config:
   browsers:
     - chrome
-  url: https://nginx/index.html
+  url: http://nginx/index.html
 
 "verify page is open":
   assertions:
-    - $page.url is "https://nginx/index.html"
+    - $page.url is "http://nginx/index.html"

--- a/tests/Functional/Services/CompilerTest.php
+++ b/tests/Functional/Services/CompilerTest.php
@@ -59,7 +59,7 @@ class CompilerTest extends AbstractBaseFunctionalTest
                         [
                             'config' => [
                                 'browser' => 'chrome',
-                                'url' => 'https://nginx/index.html'
+                                'url' => 'http://nginx/index.html'
                             ],
                             'source' => '{{ COMPILER_SOURCE_DIRECTORY }}/Test/chrome-open-index.yml',
                             'target' =>


### PR DESCRIPTION
Fixes #210