### PR TITLE
JobStateMutator::setExecutionComplete() should mutate state only if job is running

### DIFF
--- a/src/EventSubscriber/JobCompletedEventSubscriber.php
+++ b/src/EventSubscriber/JobCompletedEventSubscriber.php
@@ -4,20 +4,16 @@ declare(strict_types=1);
 
 namespace App\EventSubscriber;
 
-use App\Entity\Job;
 use App\Event\JobCompletedEvent;
 use App\Services\JobStateMutator;
-use App\Services\JobStore;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class JobCompletedEventSubscriber implements EventSubscriberInterface
 {
-    private JobStore $jobStore;
     private JobStateMutator $jobStateMutator;
 
-    public function __construct(JobStore $jobStore, JobStateMutator $jobStateMutator)
+    public function __construct(JobStateMutator $jobStateMutator)
     {
-        $this->jobStore = $jobStore;
         $this->jobStateMutator = $jobStateMutator;
     }
 
@@ -32,10 +28,6 @@ class JobCompletedEventSubscriber implements EventSubscriberInterface
 
     public function setJobStateToCompleted(): void
     {
-        $job = $this->jobStore->getJob();
-
-        if (Job::STATE_EXECUTION_RUNNING === $job->getState()) {
-            $this->jobStateMutator->setExecutionComplete();
-        }
+        $this->jobStateMutator->setExecutionComplete();
     }
 }

--- a/src/Services/JobStateMutator.php
+++ b/src/Services/JobStateMutator.php
@@ -37,7 +37,14 @@ class JobStateMutator
 
     public function setExecutionComplete(): void
     {
-        $this->set(Job::STATE_EXECUTION_COMPLETE);
+        if ($this->jobStore->hasJob()) {
+            $job = $this->jobStore->getJob();
+
+            if (Job::STATE_EXECUTION_RUNNING === $job->getState()) {
+                $job->setState(Job::STATE_EXECUTION_COMPLETE);
+                $this->jobStore->store($job);
+            }
+        }
     }
 
     public function setExecutionCancelled(): void

--- a/tests/Functional/EventSubscriber/JobCompletedEventSubscriberTest.php
+++ b/tests/Functional/EventSubscriber/JobCompletedEventSubscriberTest.php
@@ -20,6 +20,7 @@ class JobCompletedEventSubscriberTest extends AbstractBaseFunctionalTest
     private JobCompletedEventSubscriber $eventSubscriber;
     private JobStateMutator $jobStateMutator;
     private Job $job;
+    private JobStore $jobStore;
 
     protected function setUp(): void
     {
@@ -35,6 +36,7 @@ class JobCompletedEventSubscriberTest extends AbstractBaseFunctionalTest
         self::assertInstanceOf(JobStore::class, $jobStore);
         if ($jobStore instanceof JobStore) {
             $this->job = $jobStore->create('label content', 'http://example.com/callback');
+            $this->jobStore = $jobStore;
         }
 
         $jobStateMutator = self::$container->get(JobStateMutator::class);
@@ -46,65 +48,50 @@ class JobCompletedEventSubscriberTest extends AbstractBaseFunctionalTest
 
     /**
      * @dataProvider setJobStateToCompletedDataProvider
+     *
+     * @param Job::STATE_* $startState
+     * @param Job::STATE_* $expectedEndState
      */
-    public function testSetJobStateToCompleted(callable $jobMutator, string $expectedJobState)
+    public function testSetJobStateToCompleted(string $startState, string $expectedEndState)
     {
-        $jobMutator($this->jobStateMutator, $this->job);
+        $this->job->setState($startState);
+        $this->jobStore->store($this->job);
+        self::assertSame($startState, $this->job->getState());
 
         $this->eventSubscriber->setJobStateToCompleted();
-
-        self::assertSame($expectedJobState, $this->job->getState());
+        self::assertSame($expectedEndState, $this->job->getState());
     }
 
     public function setJobStateToCompletedDataProvider(): array
     {
         return [
             'job state: compilation awaiting' => [
-                'jobMutator' => function () {
-                },
-                'expectedJobState' => Job::STATE_COMPILATION_AWAITING,
+                'startState' => Job::STATE_COMPILATION_AWAITING,
+                'expectedEndState' => Job::STATE_COMPILATION_AWAITING,
             ],
             'job state: compilation running' => [
-                'jobMutator' => function (JobStateMutator $jobStateMutator, Job $job) {
-                    $jobStateMutator->setCompilationRunning();
-                    self::assertSame(Job::STATE_COMPILATION_RUNNING, $job->getState());
-                },
-                'expectedJobState' => Job::STATE_COMPILATION_RUNNING,
+                'startState' => Job::STATE_COMPILATION_RUNNING,
+                'expectedEndState' => Job::STATE_COMPILATION_RUNNING,
             ],
             'job state: compilation failed' => [
-                'jobMutator' => function (JobStateMutator $jobStateMutator, Job $job) {
-                    $jobStateMutator->setCompilationFailed();
-                    self::assertSame(Job::STATE_COMPILATION_FAILED, $job->getState());
-                },
-                'expectedJobState' => Job::STATE_COMPILATION_FAILED,
+                'startState' => Job::STATE_COMPILATION_FAILED,
+                'expectedEndState' => Job::STATE_COMPILATION_FAILED,
             ],
             'job state: execution awaiting' => [
-                'jobMutator' => function (JobStateMutator $jobStateMutator, Job $job) {
-                    $jobStateMutator->setExecutionAwaiting();
-                    self::assertSame(Job::STATE_EXECUTION_AWAITING, $job->getState());
-                },
-                'expectedJobState' => Job::STATE_EXECUTION_AWAITING,
+                'startState' => Job::STATE_EXECUTION_AWAITING,
+                'expectedEndState' => Job::STATE_EXECUTION_AWAITING,
             ],
             'job state: execution running' => [
-                'jobMutator' => function (JobStateMutator $jobStateMutator, Job $job) {
-                    $jobStateMutator->setExecutionRunning();
-                    self::assertSame(Job::STATE_EXECUTION_RUNNING, $job->getState());
-                },
-                'expectedJobState' => Job::STATE_EXECUTION_COMPLETE,
+                'startState' => Job::STATE_EXECUTION_RUNNING,
+                'expectedEndState' => Job::STATE_EXECUTION_COMPLETE,
             ],
             'job state: execution complete' => [
-                'jobMutator' => function (JobStateMutator $jobStateMutator, Job $job) {
-                    $jobStateMutator->setExecutionComplete();
-                    self::assertSame(Job::STATE_EXECUTION_COMPLETE, $job->getState());
-                },
-                'expectedJobState' => Job::STATE_EXECUTION_COMPLETE,
+                'startState' => Job::STATE_EXECUTION_COMPLETE,
+                'expectedEndState' => Job::STATE_EXECUTION_COMPLETE,
             ],
             'job state: execution cancelled' => [
-                'jobMutator' => function (JobStateMutator $jobStateMutator, Job $job) {
-                    $jobStateMutator->setExecutionCancelled();
-                    self::assertSame(Job::STATE_EXECUTION_CANCELLED, $job->getState());
-                },
-                'expectedJobState' => Job::STATE_EXECUTION_CANCELLED,
+                'startState' => Job::STATE_EXECUTION_CANCELLED,
+                'expectedEndState' => Job::STATE_EXECUTION_CANCELLED,
             ],
         ];
     }

--- a/tests/Functional/Services/JobStateMutatorTest.php
+++ b/tests/Functional/Services/JobStateMutatorTest.php
@@ -87,4 +87,59 @@ class JobStateMutatorTest extends AbstractBaseFunctionalTest
             ],
         ];
     }
+
+    /**
+     * @dataProvider setExecutionCompleteDataProvider
+     *
+     * @param Job::STATE_* $startState
+     * @param Job::STATE_* $expectedEndState
+     */
+    public function testSetExecutionComplete(string $startState, string $expectedEndState)
+    {
+        $this->job->setState($startState);
+        $this->jobStore->store($this->job);
+        self::assertSame($startState, $this->job->getState());
+
+        $this->jobStateMutator->setExecutionComplete();
+
+        self::assertSame($expectedEndState, $this->job->getState());
+    }
+
+    public function setExecutionCompleteDataProvider(): array
+    {
+        return [
+            'state: compilation-awaiting' => [
+                'startState' => Job::STATE_COMPILATION_AWAITING,
+                'expectedEndState' => Job::STATE_COMPILATION_AWAITING,
+            ],
+            'state: compilation-running' => [
+                'startState' => Job::STATE_COMPILATION_RUNNING,
+                'expectedEndState' => Job::STATE_COMPILATION_RUNNING,
+            ],
+            'state: compilation-failed' => [
+                'startState' => Job::STATE_COMPILATION_FAILED,
+                'expectedEndState' => Job::STATE_COMPILATION_FAILED,
+            ],
+            'state: execution-awaiting' => [
+                'startState' => Job::STATE_EXECUTION_AWAITING,
+                'expectedEndState' => Job::STATE_EXECUTION_AWAITING,
+            ],
+            'state: execution-running' => [
+                'startState' => Job::STATE_EXECUTION_RUNNING,
+                'expectedEndState' => Job::STATE_EXECUTION_COMPLETE,
+            ],
+            'state: execution-failed' => [
+                'startState' => Job::STATE_EXECUTION_FAILED,
+                'expectedEndState' => Job::STATE_EXECUTION_FAILED,
+            ],
+            'state: execution-complete' => [
+                'startState' => Job::STATE_EXECUTION_COMPLETE,
+                'expectedEndState' => Job::STATE_EXECUTION_COMPLETE,
+            ],
+            'state: execution-cancelled' => [
+                'startState' => Job::STATE_EXECUTION_CANCELLED,
+                'expectedEndState' => Job::STATE_EXECUTION_CANCELLED,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Fixes #348