### PR TITLE
JobStateMutator::setCompilationFailed() should mutate state only if compilation is running

### DIFF
--- a/src/Services/JobStateMutator.php
+++ b/src/Services/JobStateMutator.php
@@ -22,7 +22,7 @@ class JobStateMutator
 
     public function setCompilationFailed(): void
     {
-        $this->set(Job::STATE_COMPILATION_FAILED);
+        $this->setIfCurrentState(Job::STATE_COMPILATION_RUNNING, Job::STATE_COMPILATION_FAILED);
     }
 
     public function setExecutionAwaiting(): void
@@ -37,26 +37,17 @@ class JobStateMutator
 
     public function setExecutionComplete(): void
     {
-        if ($this->jobStore->hasJob()) {
-            $job = $this->jobStore->getJob();
-
-            if (Job::STATE_EXECUTION_RUNNING === $job->getState()) {
-                $job->setState(Job::STATE_EXECUTION_COMPLETE);
-                $this->jobStore->store($job);
-            }
-        }
+        $this->setIfCurrentState(Job::STATE_EXECUTION_RUNNING, Job::STATE_EXECUTION_COMPLETE);
     }
 
     public function setExecutionCancelled(): void
     {
-        if ($this->jobStore->hasJob()) {
-            $job = $this->jobStore->getJob();
-
-            if (false === $job->isFinished()) {
-                $job->setState(Job::STATE_EXECUTION_CANCELLED);
-                $this->jobStore->store($job);
-            }
-        }
+        $this->conditionallySetState(
+            function (Job $job): bool {
+                return false === $job->isFinished();
+            },
+            Job::STATE_EXECUTION_CANCELLED
+        );
     }
 
     /**
@@ -68,6 +59,36 @@ class JobStateMutator
             $job = $this->jobStore->getJob();
             $job->setState($state);
             $this->jobStore->store($job);
+        }
+    }
+
+    /**
+     * @param Job::STATE_* $currentState
+     * @param Job::STATE_* $state
+     */
+    private function setIfCurrentState(string $currentState, string $state): void
+    {
+        $this->conditionallySetState(
+            function (Job $job) use ($currentState): bool {
+                return $currentState === $job->getState();
+            },
+            $state
+        );
+    }
+
+    /**
+     * @param callable $conditional
+     * @param Job::STATE_* $state
+     */
+    private function conditionallySetState(callable $conditional, string $state): void
+    {
+        if ($this->jobStore->hasJob()) {
+            $job = $this->jobStore->getJob();
+
+            if (true === $conditional($job)) {
+                $job->setState($state);
+                $this->jobStore->store($job);
+            }
         }
     }
 }

--- a/tests/Functional/Services/JobStateMutatorTest.php
+++ b/tests/Functional/Services/JobStateMutatorTest.php
@@ -142,4 +142,59 @@ class JobStateMutatorTest extends AbstractBaseFunctionalTest
             ],
         ];
     }
+
+    /**
+     * @dataProvider setExecutionCompleteDataProvider
+     *
+     * @param Job::STATE_* $startState
+     * @param Job::STATE_* $expectedEndState
+     */
+    public function testSetCompilationFailed(string $startState, string $expectedEndState)
+    {
+        $this->job->setState($startState);
+        $this->jobStore->store($this->job);
+        self::assertSame($startState, $this->job->getState());
+
+        $this->jobStateMutator->setExecutionComplete();
+
+        self::assertSame($expectedEndState, $this->job->getState());
+    }
+
+    public function setCompilationFailedDataProvider(): array
+    {
+        return [
+            'state: compilation-awaiting' => [
+                'startState' => Job::STATE_COMPILATION_AWAITING,
+                'expectedEndState' => Job::STATE_COMPILATION_AWAITING,
+            ],
+            'state: compilation-running' => [
+                'startState' => Job::STATE_COMPILATION_RUNNING,
+                'expectedEndState' => Job::STATE_COMPILATION_FAILED,
+            ],
+            'state: compilation-failed' => [
+                'startState' => Job::STATE_COMPILATION_FAILED,
+                'expectedEndState' => Job::STATE_COMPILATION_FAILED,
+            ],
+            'state: execution-awaiting' => [
+                'startState' => Job::STATE_EXECUTION_AWAITING,
+                'expectedEndState' => Job::STATE_EXECUTION_AWAITING,
+            ],
+            'state: execution-running' => [
+                'startState' => Job::STATE_EXECUTION_RUNNING,
+                'expectedEndState' => Job::STATE_EXECUTION_RUNNING,
+            ],
+            'state: execution-failed' => [
+                'startState' => Job::STATE_EXECUTION_FAILED,
+                'expectedEndState' => Job::STATE_EXECUTION_FAILED,
+            ],
+            'state: execution-complete' => [
+                'startState' => Job::STATE_EXECUTION_COMPLETE,
+                'expectedEndState' => Job::STATE_EXECUTION_COMPLETE,
+            ],
+            'state: execution-cancelled' => [
+                'startState' => Job::STATE_EXECUTION_CANCELLED,
+                'expectedEndState' => Job::STATE_EXECUTION_CANCELLED,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Fixes #350